### PR TITLE
pass sink requests to sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ function merge(...sources) {
     let startCount = 0;
     let endCount = 0;
     const talkback = t => {
-      if (t !== 2) return;
-      for (let i = 0; i < n; i++) sourceTalkbacks[i](2);
+      if (t === 0) return;
+      for (let i = 0; i < n; i++) sourceTalkbacks[i](t);
     };
     for (let i = 0; i < n; i++) {
       sources[i](0, (t, d) => {


### PR DESCRIPTION
The readme makes me suspect that there's something here that I don't understand, but, is there any harm in passing on requests from the sink to the sources, making `merge` work better with pullables? I was just bitten by `merge` swallowing the upstream requests.