### PR TITLE
Allocate by using `new Array(n)`

### DIFF
--- a/readme.js
+++ b/readme.js
@@ -30,7 +30,7 @@ function merge(...sources) {
   return (start, sink) => {
     if (start !== 0) return;
     const n = sources.length;
-    const sourceTalkbacks = Array(n);
+    const sourceTalkbacks = new Array(n);
     let startCount = 0;
     let endCount = 0;
     const talkback = t => {


### PR DESCRIPTION
Array(n) is causing some deopts in v8 - https://github.com/babel/babel/issues/6233#issuecomment-329055890