### PR TITLE
Remove filtering guard in talkback

### DIFF
--- a/readme.js
+++ b/readme.js
@@ -34,7 +34,6 @@ function merge(...sources) {
     let startCount = 0;
     let endCount = 0;
     const talkback = t => {
-      if (t === 0) return;
       for (let i = 0; i < n; i++) sourceTalkbacks[i] && sourceTalkbacks[i](t);
     };
     for (let i = 0; i < n; i++) {


### PR DESCRIPTION
It seems to me such guards in talkback are totally unnecessary - sink should never send up `0` up because it violates callbag spec.